### PR TITLE
Re-layout the circuit when share with link

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -597,6 +597,9 @@ $('html').click(e => {
 
 window.onpopstate = () => {
     const hash = window.location.hash.slice(1);
+    const transform = $('#transform').prop('checked');
+    const layoutEngine = $('#layout').val();
+    const simEngine = $('#engine').val();
     if (loading || !hash) return;
     destroycircuit();
     $.ajax({
@@ -604,7 +607,9 @@ window.onpopstate = () => {
         url: '/api/circuit/' + hash,
         dataType: 'json',
         success: (responseData, status, xhr) => {
-            mkcircuit(responseData);
+            if (transform) responseData = digitaljs.transform.transformCircuit(responseData);
+            const engines = { synch: digitaljs.engines.BrowserSynchEngine, worker: digitaljs.engines.WorkerEngine };
+            mkcircuit(responseData, {layoutEngine: layoutEngine, engine: engines[simEngine]});
         },
         error: (request, status, error) => {
             loading = false;


### PR DESCRIPTION
## Summary

Circuit retrieved from `/api/circuit/` may not be transformed/processed by the layout engine before.

Re-run the layout engine on front-end once the circuit is retrieved

## Testing
Loading a circuit with the hash key.

| Before patching |  After patching |
|---|---|
| ![image](https://github.com/tilk/digitaljs_online/assets/92428218/27a0b1ea-1a71-4432-9407-599d08d6842f) | ![image](https://github.com/tilk/digitaljs_online/assets/92428218/320a9bf2-fb78-4ff2-afeb-516b382f9a4d)|