### PR TITLE
Add IEC Gates 

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -256,8 +256,8 @@
                     title="Changes the graphical symbols used to draw logic gates. Applies immediately, also to the circuit currently displayed.">
                     <label class="form-label" for="symbols">Gate symbols</label>
                     <select id="symbols" class="form-control">
-                      <option value="ansi">ANSI (IEEE 91 distinctive shapes)</option>
-                      <option value="iec">IEC 60617-12 (rectangular)</option>
+                      <option value="ansi">ANSI</option>
+                      <option value="iec">IEC</option>
                     </select>
                   </div>
                 </fieldset>

--- a/public/index.html
+++ b/public/index.html
@@ -252,6 +252,14 @@
                       <option value="dagre">Dagre (legacy)</option>
                     </select>
                   </div>
+                  <div class="mb-3" data-bs-toggle="tooltip"
+                    title="Changes the graphical symbols used to draw logic gates. Applies immediately, also to the circuit currently displayed.">
+                    <label class="form-label" for="symbols">Gate symbols</label>
+                    <select id="symbols" class="form-control">
+                      <option value="ansi">ANSI (IEEE 91 distinctive shapes)</option>
+                      <option value="iec">IEC 60617-12 (rectangular)</option>
+                    </select>
+                  </div>
                 </fieldset>
               </form>
             </div>

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -403,7 +403,9 @@ function mkcircuit(data, opts) {
     $$('form input, form textarea, form button, form select').forEach(element => {
         element.disabled = false;
     });
-    circuit = new digitaljs.Circuit(data, opts);
+    // gate symbol standard is purely presentational, so it is taken from the
+    // form on every path that creates a circuit (synthesis, load, permalink)
+    circuit = new digitaljs.Circuit(data, { symbols: $('#symbols').value, ...opts });
     circuit.on('postUpdateGates', (tick) => {
         $('#tick').value = tick;
     });
@@ -877,6 +879,10 @@ function updateFormCollapse() {
     $('#abcGateOptions').classList.toggle('show', $('#abc_gates').checked);
     $('#abcLutOptions').classList.toggle('show', $('#abc_luts').checked);
 }
+
+$('#symbols').addEventListener('change', e => {
+    if (circuit) circuit.setSymbols(e.target.value);
+});
 
 $('#fsm').addEventListener('change', updateFormCollapse);
 $('#techmap').addEventListener('change', updateFormCollapse);


### PR DESCRIPTION
This is the front-end half of a two-part change. I've also opened tilk/digitaljs, which adds the underlying symbols constructor option and Circuit#setSymbols() to the library the two are designed together

Merge order: the library PR first, then this one alongside a digitaljs dependency bump. On its own, this PR's dropdown is inert (circuit.setSymbols would be undefined), so it shouldn't be merged before the library side ships.